### PR TITLE
pre-fix gateway url with HTTP

### DIFF
--- a/ItemService/appsettings.json
+++ b/ItemService/appsettings.json
@@ -8,6 +8,6 @@
   },
   "AllowedHosts": "*",
   "Config": {
-    "ApiGatewayBaseUrl": "aci-api-gateway"
+    "ApiGatewayBaseUrl": "http://aci-api-gateway"
   }
 }

--- a/ReservationService/appsettings.json
+++ b/ReservationService/appsettings.json
@@ -8,6 +8,6 @@
   },
   "AllowedHosts": "*",
   "Config": {
-    "ApiGatewayBaseUrl": "aci-api-gateway"
+    "ApiGatewayBaseUrl": "http://aci-api-gateway"
   }
 }


### PR DESCRIPTION
Currently, Flurl is blocking URL requests because the checks inside Flurl do not allow such urls to be used.